### PR TITLE
Automatically parse panderas schema into data documentation

### DIFF
--- a/docs/data_dictionary.html
+++ b/docs/data_dictionary.html
@@ -1,0 +1,117 @@
+<h1>Titanic</h1>
+<p>
+The sinking of the Titanic is one of the most infamous  shipwrecks in history.
+On April 15, 1912, during her maiden voyage, the widely  considered “unsinkable” RMS Titanic sank after colliding  with an iceberg. Unfortunately, there weren’t enough  lifeboats for everyone onboard, resulting in the death  of 1502 out of 2224 passengers and crew.
+While there was some element of luck involved in surviving,  it seems some groups of people were more likely to survive than others.
+
+<p>
+<table border="1" class="dataframe docutils align-default">
+  <thead>
+    <tr style="text-align: right;">
+      <th>name</th>
+      <th>comment</th>
+      <th>pandas_dtype</th>
+      <th>nullable</th>
+      <th>allow_duplicates</th>
+      <th>checks</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>passengerid</td>
+      <td>Passenger ID</td>
+      <td>int64</td>
+      <td>✗</td>
+      <td>✗</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>survived</td>
+      <td>Survival where 1 = survived, and 0 = perished</td>
+      <td>int64</td>
+      <td>✗</td>
+      <td>✓</td>
+      <td>{'isin': [0, 1]}</td>
+    </tr>
+    <tr>
+      <td>pclass</td>
+      <td>Passenger Class.  PClass can be a proxy for socio-economic status (SES)* 1st ~ Upper * 2nd ~ Middle * 3rd ~ Lower</td>
+      <td>int64</td>
+      <td>✗</td>
+      <td>✓</td>
+      <td>{'isin': [1, 2, 3]}</td>
+    </tr>
+    <tr>
+      <td>name</td>
+      <td>First and Last Name</td>
+      <td>str</td>
+      <td>✓</td>
+      <td>✗</td>
+      <td>{'str_length': {'min_value': 12, 'max_value': 82}}</td>
+    </tr>
+    <tr>
+      <td>sex</td>
+      <td>Passenger sex</td>
+      <td>Int64</td>
+      <td>✗</td>
+      <td>✓</td>
+      <td>{'isin': [0, 1]}</td>
+    </tr>
+    <tr>
+      <td>age</td>
+      <td>Passenger age</td>
+      <td>float64</td>
+      <td>✓</td>
+      <td>✓</td>
+      <td>{'in_range': {'min_value': 0, 'max_value': 80}}</td>
+    </tr>
+    <tr>
+      <td>sibsp</td>
+      <td>Number of Siblings/Spouses Aboard. Sibling: Brother, Sister, Stepbrother, or Stepsister of  Passenger Aboard Titanic Spouse: Husband or Wife of Passenger  Aboard Titanic (Mistresses and Fiances Ignored)</td>
+      <td>int64</td>
+      <td>✗</td>
+      <td>✓</td>
+      <td>{'in_range': {'min_value': 0, 'max_value': 8}}</td>
+    </tr>
+    <tr>
+      <td>parch</td>
+      <td>Number of Parents/Children Aboard. Parent: Mother or Father of  Passenger Aboard Titanic Child: Son, Daughter, Stepson, or  Stepdaughter of Passenger Aboard Titanic</td>
+      <td>int64</td>
+      <td>✗</td>
+      <td>✓</td>
+      <td>{'in_range': {'min_value': 0, 'max_value': 6}}</td>
+    </tr>
+    <tr>
+      <td>ticket</td>
+      <td>Ticket Number</td>
+      <td>str</td>
+      <td>✓</td>
+      <td>✓</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>fare</td>
+      <td>Passenger Fare</td>
+      <td>float64</td>
+      <td>✗</td>
+      <td>✓</td>
+      <td>{'in_range': {'min_value': 0, 'max_value': 513}}</td>
+    </tr>
+    <tr>
+      <td>cabin</td>
+      <td>Cabin number</td>
+      <td>str</td>
+      <td>✓</td>
+      <td>✓</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>embarked</td>
+      <td>Port of Embarkation where C = Cherbourg;  Q = Queenstown; S = Southampton</td>
+      <td>int64</td>
+      <td>✓</td>
+      <td>✓</td>
+      <td>{'isin': ['S', 'C', 'Q']}</td>
+    </tr>
+  </tbody>
+</table>

--- a/docs/data_dictionary.html
+++ b/docs/data_dictionary.html
@@ -1,8 +1,8 @@
 <h1>Titanic</h1>
 <p>
-The sinking of the Titanic is one of the most infamous  shipwrecks in history.
-On April 15, 1912, during her maiden voyage, the widely  considered “unsinkable” RMS Titanic sank after colliding  with an iceberg. Unfortunately, there weren’t enough  lifeboats for everyone onboard, resulting in the death  of 1502 out of 2224 passengers and crew.
-While there was some element of luck involved in surviving,  it seems some groups of people were more likely to survive than others.
+The sinking of the Titanic is one of the most infamous shipwrecks in history.
+On April 15, 1912, during her maiden voyage, the widely considered “unsinkable” RMS Titanic sank after colliding with an iceberg. Unfortunately, there weren’t enough lifeboats for everyone onboard, resulting in the death of 1502 out of 2224 passengers and crew.
+While there was some element of luck involved in surviving, it seems some groups of people were more likely to survive than others.
 
 <p>
 <table border="1" class="dataframe docutils align-default">
@@ -35,7 +35,7 @@ While there was some element of luck involved in surviving,  it seems some group
     </tr>
     <tr>
       <td>pclass</td>
-      <td>Passenger Class.  PClass can be a proxy for socio-economic status (SES)* 1st ~ Upper * 2nd ~ Middle * 3rd ~ Lower</td>
+      <td>Passenger Class. PClass can be a proxy for socio-economic status (SES)* 1st ~ Upper * 2nd ~ Middle * 3rd ~ Lower</td>
       <td>int64</td>
       <td>✗</td>
       <td>✓</td>
@@ -67,7 +67,7 @@ While there was some element of luck involved in surviving,  it seems some group
     </tr>
     <tr>
       <td>sibsp</td>
-      <td>Number of Siblings/Spouses Aboard. Sibling: Brother, Sister, Stepbrother, or Stepsister of  Passenger Aboard Titanic Spouse: Husband or Wife of Passenger  Aboard Titanic (Mistresses and Fiances Ignored)</td>
+      <td>Number of Siblings/Spouses Aboard.Sibling: Brother, Sister, Stepbrother, or Stepsister of Passenger Aboard Titanic Spouse: Husband or Wife of Passenger Aboard Titanic (Mistresses and Fiances Ignored)</td>
       <td>int64</td>
       <td>✗</td>
       <td>✓</td>
@@ -75,7 +75,7 @@ While there was some element of luck involved in surviving,  it seems some group
     </tr>
     <tr>
       <td>parch</td>
-      <td>Number of Parents/Children Aboard. Parent: Mother or Father of  Passenger Aboard Titanic Child: Son, Daughter, Stepson, or  Stepdaughter of Passenger Aboard Titanic</td>
+      <td>Number of Parents/Children Aboard. Parent: Mother or Father of Passenger Aboard Titanic Child: Son, Daughter, Stepson, or Stepdaughter of Passenger Aboard Titanic</td>
       <td>int64</td>
       <td>✗</td>
       <td>✓</td>
@@ -107,7 +107,7 @@ While there was some element of luck involved in surviving,  it seems some group
     </tr>
     <tr>
       <td>embarked</td>
-      <td>Port of Embarkation where C = Cherbourg;  Q = Queenstown; S = Southampton</td>
+      <td>Port of Embarkation where C = Cherbourg; Q = Queenstown; S = Southampton</td>
       <td>int64</td>
       <td>✓</td>
       <td>✓</td>

--- a/docs/data_dictionary.html
+++ b/docs/data_dictionary.html
@@ -5,7 +5,7 @@ On April 15, 1912, during her maiden voyage, the widely considered “unsinkable
 While there was some element of luck involved in surviving, it seems some groups of people were more likely to survive than others.
 
 <p>
-<table border="1" class="dataframe docutils align-default">
+<table border="1" style="max-width:300px;" class="dataframe docutils align-default">
   <thead>
     <tr style="text-align: right;">
       <th>name</th>

--- a/docs/data_dictionary.rst
+++ b/docs/data_dictionary.rst
@@ -1,0 +1,9 @@
+Data dictionary
+===============
+
+.. contents::
+    :local:
+    :backlinks: none
+
+.. raw:: html
+   :file: data_dictionary.html

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,10 +2,11 @@
    :hidden:
    :maxdepth: 1
 
-   license
+   data_dictionary
    reference_etl
    reference_model
    reference_post
    reference_utils
+   license
 
 .. mdinclude:: ../README.md

--- a/ndj_pipeline/post.py
+++ b/ndj_pipeline/post.py
@@ -38,9 +38,8 @@ from ndj_pipeline import utils
 # Hack to get plots working correctly on command line
 try:
     if get_ipython().__class__.__name__ == "ZMQInteractiveShell":  # type: ignore
-        logging.debug("Running with ipython support")
+        pass
 except NameError:
-    logging.debug("ipython not detected, setting matplotlib backend")
     matplotlib.use("agg")
 
 five_thirty_eight = [

--- a/ndj_pipeline/utils.py
+++ b/ndj_pipeline/utils.py
@@ -100,23 +100,23 @@ def create_tables_html() -> None:
     """Scan schemas directory to create HTML page for data documentation."""
     schema_paths = Path("schemas").glob("*.yaml")
 
-    html = []
+    html_list = []
     for schema_path in schema_paths:
         logging.info(f"Loading schema from {schema_path}")
         with open(schema_path, "r") as f:
             schema = yaml.safe_load(f)
 
         table_name = f"<h1>{schema_path.stem.title()}</h1>"
-        html.append(table_name)
+        html_list.append(table_name)
         table_comment = schema.get("comment", "")
-        html.append(table_comment)
+        html_list.append(table_comment)
         table_html = parse_schema_to_table(schema)
-        html.append(table_html)
+        html_list.append(table_html)
 
     output_path = Path("docs", "data_dictionary.html")
     logging.info(f"Saving data dictionary to {output_path}")
 
-    html = "\n<p>\n".join(html)
+    html = "\n<p>\n".join(html_list)
 
     with open(output_path, "w") as f:
         f.write(html)
@@ -137,7 +137,7 @@ def parse_schema_to_table(schema: Dict[str, Any]) -> str:
 
 
 def main() -> None:
-    """Run selected utility function
+    """Run selected utility function.
 
     Can be run from command line using...
     `python -m ndj_pipeline.utils --tables`
@@ -168,7 +168,7 @@ def main() -> None:
         logging.warning(msg)
 
     if args.tables:
-        logging.info(f"Running html table creation for data dictionary")
+        logging.info("Running html table creation for data dictionary")
         create_tables_html()
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -67,4 +67,5 @@ def docs(session: Session) -> None:
     """Build documentation."""
     session.run("poetry", "install", "--no-dev", "--extras", "docs", external=True)
     session.run("rm", "-rf", "docs/_build")
+    session.run("python", "-m", "ndj_pipeline.utils", "--tables")
     session.run("sphinx-build", "docs", "docs/_build", *session.posargs)

--- a/schemas/titanic.yaml
+++ b/schemas/titanic.yaml
@@ -1,5 +1,17 @@
 schema_type: dataframe
 version: 0.6.2
+comment: >
+  The sinking of the Titanic is one of the most infamous
+  shipwrecks in history.
+
+  On April 15, 1912, during her maiden voyage, the widely
+  considered “unsinkable” RMS Titanic sank after colliding
+  with an iceberg. Unfortunately, there weren’t enough
+  lifeboats for everyone onboard, resulting in the death
+  of 1502 out of 2224 passengers and crew.
+
+  While there was some element of luck involved in surviving,
+  it seems some groups of people were more likely to survive than others.
 columns:
   passengerid:
     comment: >
@@ -12,7 +24,7 @@ columns:
 
   survived:
     comment: >
-      xyz
+      Survival where 1 = survived, and 0 = perished
     pandas_dtype: int64
     nullable: false
     checks:
@@ -25,7 +37,12 @@ columns:
 
   pclass:
     comment: >
-      Travel class
+      Passenger Class.
+      PClass can be a proxy for socio-economic status (SES)
+
+      * 1st ~ Upper
+      * 2nd ~ Middle
+      * 3rd ~ Lower
     pandas_dtype: int64
     nullable: false
     checks:
@@ -39,7 +56,7 @@ columns:
 
   name:
     comment: >
-      Passenger name on ticket
+      First and Last Name
     pandas_dtype: str
     nullable: true
     checks:
@@ -78,7 +95,11 @@ columns:
 
   sibsp:
     comment: >
-      Unknown, could be related passengers
+      Number of Siblings/Spouses Aboard.
+
+      Sibling: Brother, Sister, Stepbrother, or Stepsister of
+      Passenger Aboard Titanic Spouse: Husband or Wife of Passenger
+      Aboard Titanic (Mistresses and Fiances Ignored)
     pandas_dtype: int64
     nullable: false
     checks:
@@ -91,7 +112,9 @@ columns:
 
   parch:
     comment: >
-      Unknown, parch
+      Number of Parents/Children Aboard. Parent: Mother or Father of
+      Passenger Aboard Titanic Child: Son, Daughter, Stepson, or
+      Stepdaughter of Passenger Aboard Titanic
     pandas_dtype: int64
     nullable: false
     checks:
@@ -104,7 +127,7 @@ columns:
 
   ticket:
     comment: >
-      Ticket information
+      Ticket Number
     pandas_dtype: str
     nullable: true
     allow_duplicates: true
@@ -113,7 +136,7 @@ columns:
 
   fare:
     comment: >
-      Fare paid
+      Passenger Fare
     pandas_dtype: float64
     nullable: false
     checks:
@@ -135,7 +158,8 @@ columns:
 
   embarked:
     comment: >
-      xyz
+      Port of Embarkation where C = Cherbourg;
+      Q = Queenstown; S = Southampton
     pandas_dtype: int64
     nullable: true
     checks:


### PR DESCRIPTION
This PR adds functionality to convert Panderas yaml into tables for data documentation.

It uses name of the original file as header, 'comment' in yaml as preamble, and takes up the table and formats.

Fixes a bug in logging.